### PR TITLE
Auto deploy to Heroku Workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,20 @@
+name: Deploy to Heroku
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - 'main'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: akhileshns/heroku-deploy@v3.13.15
+        with:
+          heroku_api_key: ${{secrets.HEROKU_API_KEY}}
+          heroku_app_name: "fitoness-tracker"
+          heroku_email: "elmfer11@outlook.com"
+          usedocker: true
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM node:18:18
+
+COPY package.json ./
+
+COPY ./client/package.json ./client/package.json
+
+COPY ./server/package.json ./server/package.json
+
+RUN npm install
+
+COPY . .
+
+RUN npm run build
+
+EXPOSE 3000-4000
+
+ENV NODE_ENV=production
+
+CMD ["npm", "run", "start"]


### PR DESCRIPTION
**Note: This will not work at the moment. Check first comment for more info.**

This feature benefits us from having to manually deploy our application to Heroku.

## How Does it Deploy
Heroku allows an application to be run from a Docker container. This takes advantage of that by instructing Docker on how to build and run our application. Once the container is built, it is sent to Heroku to where is run automatically.

What `.github/workflows/deploy.yml` does is that is to download our source code from the `main` branch, builds its Docker container, and sends the built container to Heroku automatically by instructing the app to deploy to and a given Heroku API key.

## When Does it Deploy
It can deploy on either of the two triggers:
#### Push to main branch
When a commit is push directly to the `main` branch, it will treat it as changes to production code, so it deploys automatically. On top of that, whenever a pull-request is reviewed and merged to the `main` branch, it will also trigger this workflow
#### Manual Workflow Dispatch
In cases where code needs to be deployed other than the `main` branch, this workflow can be triggered manually in the `Actions` page of our repository. Before manual dispatch, you can choose a different branch to deploy from. This should be used wisely, either for CD testing, or quick fixes.